### PR TITLE
vim: noshowmode

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -17,6 +17,7 @@ set number "relativenumber
 set ruler nowrap
 set foldcolumn=1
 set hlsearch incsearch showmatch
+set noshowmode
 
 set autoindent
 set cinoptions=:0,t0,+4,(4


### PR DESCRIPTION
- redundant if `vim-airline` is used