### PR TITLE
vim: configuration for ale

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -120,3 +120,8 @@ endfunction
 " https://github.com/vim-airline/vim-airline-themes
 let g:airline_theme = 'molokai'
 let g:airline#extensions#tabline#enabled = 1
+
+" https://github.com/w0rp/ale
+let g:ale_sign_column_always = 1
+let g:ale_lint_on_text_changed = 'normal'
+let g:ale_lint_on_insert_leave = 1


### PR DESCRIPTION
- add ale configuration
- `ale_sign_column_always` keeps the sign column open all the time, so
  it doesn't keep moving the columns back and forth
- `ale_lint_on_text_changed = 'normal'` only lints when text changes
  from normal mode
- `ale_lint_on_insert_leave` performs a lint whenever insert mode is
  left

- these combined means linting does not take place while typing, but
  when insert mode is left it will run, or when text is changed from
  within normal mode