### PR TITLE
vim: templates

### DIFF
--- a/vim/Makefile
+++ b/vim/Makefile
@@ -10,7 +10,7 @@ PACK_START	= \
 	tpope/vim-abolish\
 	tpope/vim-unimpaired\
 	tpope/vim-db\
-  tpope/vim-dispatch
+	tpope/vim-dispatch
 
 PACK_OPT	=
 #	bling/vim-bufferline.git
@@ -25,7 +25,9 @@ install:
 	test -e ~/.vimrc && mv ~/.vimrc ~/.vimrc.bk || true
 	install vimrc ~/.vimrc
 	mkdir -p ~/.vim/after/ftplugin
+	mkdir -p ~/.vim/template
 	install after/* ~/.vim/after/ftplugin
+	install template/* ~/.vim/template
 
 ##
 #	packages

--- a/vim/after/perl.vim
+++ b/vim/after/perl.vim
@@ -3,3 +3,5 @@ setlocal foldmethod=expr
 setlocal makeprg=perl\ -c\ -MVi::QuickFix\ %
 setlocal errorformat+=%m\ at\ %f\ line\ %l.
 setlocal errorformat+=%m\ at\ %f\ line\ %l
+
+let g:ale_linters = {'perl': ['perl','perlcritic']}

--- a/vim/template/perl.pl
+++ b/vim/template/perl.pl
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+#
+##
+use strict;
+use Data::Dumper
+
+$Data::Dumper::Sortkeys	= 1;
+$Data::Dumper::Terse	= 1;
+
+use Pod::Usage;
+use Getopt::Long qw(
+	:config
+	require_order
+	bundling
+	no_ignore_case
+);
+
+
+
+exit(0);
+
+__END__
+
+=head1 NAME
+
+=head1 SYNOPSIS
+
+=head1 OPTIONS
+
+=cut

--- a/vim/template/perl.pm
+++ b/vim/template/perl.pm
@@ -1,0 +1,21 @@
+package REPLACE::ME;
+
+use strict;
+use Data::Dumper;
+
+$Data::Dumper::Sortkeys	= 1;
+$Data::Dumper::Terse	= 1;
+
+1;
+
+__END__
+
+=head1 NAME
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+=head1 METHODS
+
+=cut

--- a/vim/template/perl.t
+++ b/vim/template/perl.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+#
+##
+use strict;
+
+use Data::Dumper;
+$Data::Dumper::Sortkeys	= 1;
+$Data::Dumper::Terse	= 1;
+
+use Test::More;
+
+exit(0);

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -110,3 +110,7 @@ let g:airline#extensions#tabline#enabled = 1
 let g:ale_sign_column_always = 1
 let g:ale_lint_on_text_changed = 'normal'
 let g:ale_lint_on_insert_leave = 1
+
+autocmd BufNewFile *.pm -1r ~/.vim/template/perl.pm
+autocmd BufNewFile *.pl -1r ~/.vim/template/perl.pl
+autocmd BufNewFile *.t  -1r ~/.vim/template/perl.t


### PR DESCRIPTION
- add perl template files to `~/.vim/template/`
- move the `ale_linters` definition for perl to after/ftplugin